### PR TITLE
Renew system

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -42,9 +42,11 @@ PODS:
     - Nimble (~> 7.0)
   - Protobuf (3.5.0)
   - Quick (1.2.0)
+  - Result (3.2.4)
   - Tsuchi (0.1.1):
     - Firebase/Core
     - Firebase/Messaging
+    - Result
 
 DEPENDENCIES:
   - FBSnapshotTestCase (~> 2.1.4)
@@ -70,7 +72,8 @@ SPEC CHECKSUMS:
   Nimble-Snapshots: f5459b5b091678dc942d03ec4741cacb58ba4a52
   Protobuf: 8a9838fba8dae3389230e1b7f8c104aa32389c03
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
-  Tsuchi: 4ce6ed964dce9645291ad54ee083e08d5568bc96
+  Result: d2d07204ce72856f1fd9130bbe42c35a7b0fea10
+  Tsuchi: 77718c8680173cff77c660774806da5f18318275
 
 PODFILE CHECKSUM: e5307c00f8c9f4914548bba9ce7e86e0015cbb6b
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -42,7 +42,7 @@ PODS:
     - Nimble (~> 7.0)
   - Protobuf (3.5.0)
   - Quick (1.2.0)
-  - Tsuchi (0.1.0):
+  - Tsuchi (0.1.1):
     - Firebase/Core
     - Firebase/Messaging
 
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   Nimble-Snapshots: f5459b5b091678dc942d03ec4741cacb58ba4a52
   Protobuf: 8a9838fba8dae3389230e1b7f8c104aa32389c03
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
-  Tsuchi: d239f8950fdcd231095388f975aa74ea89d2ac4b
+  Tsuchi: 4ce6ed964dce9645291ad54ee083e08d5568bc96
 
 PODFILE CHECKSUM: e5307c00f8c9f4914548bba9ce7e86e0015cbb6b
 

--- a/Example/Tsuchi.xcodeproj/project.pbxproj
+++ b/Example/Tsuchi.xcodeproj/project.pbxproj
@@ -304,12 +304,14 @@
 				"${SRCROOT}/Pods/Target Support Files/Pods-Tsuchi_Example/Pods-Tsuchi_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework",
 				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
+				"${BUILT_PRODUCTS_DIR}/Result/Result.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleToolboxForMac.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Protobuf.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Result.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Tsuchi/NotificationHandler.swift
+++ b/Example/Tsuchi/NotificationHandler.swift
@@ -8,7 +8,7 @@
 
 import Tsuchi
 
-struct PushNotification: PushNotificationProtocol {
+struct PushNotification: PushNotificationPayload {
     let hoge: String
     let hige: String
     var aps: APS?
@@ -16,22 +16,23 @@ struct PushNotification: PushNotificationProtocol {
 
 class NotificationHandler {
     static let shared = NotificationHandler()
-    private let tsuchi: Tsuchi<PushNotification> = Tsuchi()
+    private let tsuchi = Tsuchi.shared
 
     private init() {
         // initialize your tsuchi settings
-        tsuchi.isShowingBanner = true
+        tsuchi.showsNotificationBannerOnPresenting = true
 
         tsuchi.didRefreshRegistrationTokenActionBlock = { token in
             print(token)
         }
 
-        tsuchi.didOpenApplicationFromNotificationActionBlock = { pushNotification in
-            print(pushNotification)
-        }
-
-        tsuchi.didReceiveRemoteNotificationActionBlock = { pushNotification in
-            print(pushNotification)
+        tsuchi.subscribe(PushNotification.self) { result in
+            switch result {
+            case let .success((payload, mode)):
+                print("reiceived: \(payload), mode: \(mode)")
+            case let .failure(error):
+                print("error: \(error)")
+            }
         }
     }
 

--- a/NotificationMode.swift
+++ b/NotificationMode.swift
@@ -1,0 +1,12 @@
+//
+//  NotificationMode.swift
+//
+//  Created by suguru-kishimoto on 2018/01/11.
+//
+
+import Foundation
+
+public enum NotificationMode {
+    case willPresent
+    case didReceive
+}

--- a/SubscribeContainer.swift
+++ b/SubscribeContainer.swift
@@ -1,0 +1,11 @@
+//
+//  SubscribeContainer.swift
+//
+//  Created by suguru-kishimoto on 2018/01/11.
+//
+
+import Foundation
+
+public protocol SubscribeContainer {
+    func parse(_ json: [AnyHashable: Any], mode: NotificationMode)
+}

--- a/Tsuchi.podspec
+++ b/Tsuchi.podspec
@@ -20,4 +20,5 @@ You can define type safe Notification object, and handle it.
   s.static_framework = true
   s.dependency 'Firebase/Core'
   s.dependency 'Firebase/Messaging'
+  s.dependency 'Result'
 end

--- a/Tsuchi/Classes/PushNotificationPayload.swift
+++ b/Tsuchi/Classes/PushNotificationPayload.swift
@@ -1,5 +1,5 @@
 //
-//  NotificationProtocol.swift
+//  PushNotificationPayload.swift
 //  Tsuchi
 //
 //  Created by kazuya-miura on 2017/12/07.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol PushNotificationProtocol: Decodable {
+public protocol PushNotificationPayload: Decodable {
     var aps: APS? { get }
 }
 


### PR DESCRIPTION
- Introduced [`Result`](https://github.com/antitypical/Result)
- `Tsuchi` is now working as singleton.
    - Using Type-erasure(SubscribeContainer)
- Fixed `APS`'s decode logic.
  - Compatible to title only alert and alert that contain title/body.

```json
{
  "aps": {
    "alert": "foobar"
  }
}

{
  "aps": {
    "alert": {
      "title": "foobar",
      "title": "Lorem ipsum dolor sit amet, ..."
    }
  }
}
```