### PR TITLE
Fix access control

### DIFF
--- a/Tsuchi/Classes/PushNotificationPayload.swift
+++ b/Tsuchi/Classes/PushNotificationPayload.swift
@@ -13,8 +13,8 @@ public protocol PushNotificationPayload: Decodable {
 
 public struct APS: Decodable {
     public struct Alert: Decodable {
-        let body: String?
-        let title: String?
+        public let body: String?
+        public let title: String?
     }
     public let alert: Alert?
     public let badge: Int?


### PR DESCRIPTION
## Problem
<img width="774" alt="2018-11-11 2 03 17" src="https://user-images.githubusercontent.com/1413408/48304030-fb8b6e80-e555-11e8-9153-6311359be77d.png">

(Xcode 10.1, Swift 4.2.1)

## Solution

- Make `public` struct properties explicitly

Reference

>The structure’s members (including the numberOfEdits property) therefore have an internal access level by default. 
https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html#ID18

Please review 🙏 @miuP 