### PR TITLE
bugfix unregisterForRemoteNotifications

### DIFF
--- a/Tsuchi/Classes/Tsuchi.swift
+++ b/Tsuchi/Classes/Tsuchi.swift
@@ -56,9 +56,7 @@ public class Tsuchi<T: PushNotificationProtocol>: NSObject, UNUserNotificationCe
     }
 
     public func unregister(completion: (() -> Void)?) {
-        if UIApplication.shared.isRegisteredForRemoteNotifications {
-            UIApplication.shared.unregisterForRemoteNotifications()
-        }
+        UIApplication.shared.unregisterForRemoteNotifications()
         completion?()
     }
 


### PR DESCRIPTION
`UIApplication.shared.isRegisteredForRemoteNotifications`  should be called in Property in ` application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`.
Other than that it did not function.
For example, if a user deletes an application while allowing notification, it will always return True at the next installation.