### PR TITLE
Fixed payload decode logic and support Swift5

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,5 +1,6 @@
 use_frameworks!
 platform :ios, '11.0'
+inhibit_all_warnings!
 
 target 'Tsuchi_Example' do
   pod 'Tsuchi', :path => '../'
@@ -8,9 +9,9 @@ target 'Tsuchi_Example' do
   target 'Tsuchi_Tests' do
     inherit! :search_paths
 
-    pod 'Quick', '~> 1.2'
-  pod 'Nimble', '~> 7.3'
+    pod 'Quick', '~> 2.0'
+  pod 'Nimble', '~> 8.0'
   pod 'FBSnapshotTestCase' , '~> 2.1'
-  pod 'Nimble-Snapshots' , '~> 6.3'
+  pod 'Nimble-Snapshots'
   end
 end

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -10,8 +10,8 @@ target 'Tsuchi_Example' do
     inherit! :search_paths
 
     pod 'Quick', '~> 2.0'
-  pod 'Nimble', '~> 8.0'
-  pod 'FBSnapshotTestCase' , '~> 2.1'
-  pod 'Nimble-Snapshots'
+    pod 'Nimble', '~> 8.0'
+    pod 'FBSnapshotTestCase' , '~> 2.1'
+    pod 'Nimble-Snapshots'
   end
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -80,11 +80,9 @@ PODS:
     - Nimble (~> 8.0)
   - Protobuf (3.7.0)
   - Quick (2.0.0)
-  - Result (4.1.0)
   - Tsuchi (0.4.3):
     - Firebase/Core (~> 5.0)
     - Firebase/Messaging (~> 5.0)
-    - Result
 
 DEPENDENCIES:
   - FBSnapshotTestCase (~> 2.1)
@@ -112,7 +110,6 @@ SPEC REPOS:
     - Nimble-Snapshots
     - Protobuf
     - Quick
-    - Result
 
 EXTERNAL SOURCES:
   Tsuchi:
@@ -135,9 +132,8 @@ SPEC CHECKSUMS:
   Nimble-Snapshots: 2d6d712ceb2d1850d88f850fbd7c732618106022
   Protobuf: 7a877b7f3e5964e3fce995e2eb323dbc6831bb5a
   Quick: ce1276c7c27ba2da3cb2fd0cde053c3648b3b22d
-  Result: bd966fac789cc6c1563440b348ab2598cc24d5c7
-  Tsuchi: 614440581f5c8279e5def5181fe26e9f91a2e6eb
+  Tsuchi: 31b91d73c46701c84c5390e42bc1dcf80a1cd769
 
-PODFILE CHECKSUM: 4e6ae7bff20f40cd0aec3746db40998932770c92
+PODFILE CHECKSUM: 655b958924b6246744a7cdb2d0c7261e7a0a88e4
 
 COCOAPODS: 1.5.2

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,71 +4,84 @@ PODS:
   - FBSnapshotTestCase/Core (2.1.4)
   - FBSnapshotTestCase/SwiftSupport (2.1.4):
     - FBSnapshotTestCase/Core
-  - Firebase/Core (5.6.0):
+  - Firebase/Core (5.20.2):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (= 5.1.1)
-  - Firebase/CoreOnly (5.6.0):
-    - FirebaseCore (= 5.1.1)
-  - Firebase/Messaging (5.6.0):
+    - FirebaseAnalytics (= 5.8.1)
+  - Firebase/CoreOnly (5.20.2):
+    - FirebaseCore (= 5.4.1)
+  - Firebase/Messaging (5.20.2):
     - Firebase/CoreOnly
-    - FirebaseMessaging (= 3.1.0)
-  - FirebaseAnalytics (5.1.1):
-    - FirebaseCore (~> 5.1)
-    - FirebaseInstanceID (~> 3.2)
-    - GoogleAppMeasurement (~> 5.1)
-    - GoogleUtilities/AppDelegateSwizzler (~> 5.2.0)
-    - GoogleUtilities/MethodSwizzler (~> 5.2.0)
+    - FirebaseMessaging (= 3.5.0)
+  - FirebaseAnalytics (5.8.1):
+    - FirebaseCore (~> 5.4)
+    - FirebaseInstanceID (~> 3.8)
+    - GoogleAppMeasurement (= 5.8.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 5.2)
+    - GoogleUtilities/MethodSwizzler (~> 5.2)
     - GoogleUtilities/Network (~> 5.2)
     - "GoogleUtilities/NSData+zlib (~> 5.2)"
     - nanopb (~> 0.3)
-  - FirebaseCore (5.1.1):
-    - GoogleUtilities/Logger (~> 5.2)
-  - FirebaseInstanceID (3.2.1):
-    - FirebaseCore (~> 5.1)
+  - FirebaseAnalyticsInterop (1.2.0)
+  - FirebaseCore (5.4.1):
     - GoogleUtilities/Environment (~> 5.2)
-  - FirebaseMessaging (3.1.0):
-    - FirebaseCore (~> 5.0)
-    - FirebaseInstanceID (~> 3.0)
-    - GoogleUtilities/Reachability (~> 5.2)
+    - GoogleUtilities/Logger (~> 5.2)
+  - FirebaseInstanceID (3.8.1):
+    - FirebaseCore (~> 5.2)
+    - GoogleUtilities/Environment (~> 5.2)
+    - GoogleUtilities/UserDefaults (~> 5.2)
+  - FirebaseMessaging (3.5.0):
+    - FirebaseAnalyticsInterop (~> 1.1)
+    - FirebaseCore (~> 5.2)
+    - FirebaseInstanceID (~> 3.6)
+    - GoogleUtilities/Environment (~> 5.3)
+    - GoogleUtilities/Reachability (~> 5.3)
+    - GoogleUtilities/UserDefaults (~> 5.3)
     - Protobuf (~> 3.1)
-  - GoogleAppMeasurement (5.1.1):
-    - GoogleUtilities/AppDelegateSwizzler (~> 5.2.0)
-    - GoogleUtilities/MethodSwizzler (~> 5.2.0)
+  - GoogleAppMeasurement (5.8.1):
+    - GoogleUtilities/AppDelegateSwizzler (~> 5.2)
+    - GoogleUtilities/MethodSwizzler (~> 5.2)
     - GoogleUtilities/Network (~> 5.2)
     - "GoogleUtilities/NSData+zlib (~> 5.2)"
     - nanopb (~> 0.3)
-  - GoogleUtilities/AppDelegateSwizzler (5.2.2):
+  - GoogleUtilities/AppDelegateSwizzler (5.7.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (5.2.2)
-  - GoogleUtilities/Logger (5.2.2):
+  - GoogleUtilities/Environment (5.7.0)
+  - GoogleUtilities/Logger (5.7.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (5.2.2):
+  - GoogleUtilities/MethodSwizzler (5.7.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (5.2.2):
+  - GoogleUtilities/Network (5.7.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (5.2.2)"
-  - GoogleUtilities/Reachability (5.2.2):
+  - "GoogleUtilities/NSData+zlib (5.7.0)"
+  - GoogleUtilities/Reachability (5.7.0):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/UserDefaults (5.7.0):
     - GoogleUtilities/Logger
   - I (0.1.0)
-  - nanopb (0.3.8):
-    - nanopb/decode (= 0.3.8)
-    - nanopb/encode (= 0.3.8)
-  - nanopb/decode (0.3.8)
-  - nanopb/encode (0.3.8)
-  - Nimble (7.3.0)
-  - Nimble-Snapshots (6.3.0):
-    - Nimble-Snapshots/Core (= 6.3.0)
-  - Nimble-Snapshots/Core (6.3.0):
-    - FBSnapshotTestCase (~> 2.0)
-    - Nimble (~> 7.0)
-  - Protobuf (3.6.1)
-  - Quick (1.2.0)
-  - Result (4.0.0)
-  - Tsuchi (0.3.2):
+  - iOSSnapshotTestCase (6.0.3):
+    - iOSSnapshotTestCase/SwiftSupport (= 6.0.3)
+  - iOSSnapshotTestCase/Core (6.0.3)
+  - iOSSnapshotTestCase/SwiftSupport (6.0.3):
+    - iOSSnapshotTestCase/Core
+  - nanopb (0.3.901):
+    - nanopb/decode (= 0.3.901)
+    - nanopb/encode (= 0.3.901)
+  - nanopb/decode (0.3.901)
+  - nanopb/encode (0.3.901)
+  - Nimble (8.0.1)
+  - Nimble-Snapshots (7.0.0):
+    - Nimble-Snapshots/Core (= 7.0.0)
+  - Nimble-Snapshots/Core (7.0.0):
+    - iOSSnapshotTestCase (~> 6.0)
+    - Nimble (~> 8.0)
+  - Protobuf (3.7.0)
+  - Quick (2.0.0)
+  - Result (4.1.0)
+  - Tsuchi (0.4.3):
     - Firebase/Core (~> 5.0)
     - Firebase/Messaging (~> 5.0)
     - Result
@@ -76,9 +89,9 @@ PODS:
 DEPENDENCIES:
   - FBSnapshotTestCase (~> 2.1)
   - I
-  - Nimble (~> 7.3)
-  - Nimble-Snapshots (~> 6.3)
-  - Quick (~> 1.2)
+  - Nimble (~> 8.0)
+  - Nimble-Snapshots
+  - Quick (~> 2.0)
   - Tsuchi (from `../`)
 
 SPEC REPOS:
@@ -86,12 +99,14 @@ SPEC REPOS:
     - FBSnapshotTestCase
     - Firebase
     - FirebaseAnalytics
+    - FirebaseAnalyticsInterop
     - FirebaseCore
     - FirebaseInstanceID
     - FirebaseMessaging
     - GoogleAppMeasurement
     - GoogleUtilities
     - I
+    - iOSSnapshotTestCase
     - nanopb
     - Nimble
     - Nimble-Snapshots
@@ -105,22 +120,24 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  Firebase: 75ea9e232eefa158c1049028030b8f661a2ccb62
-  FirebaseAnalytics: 993577e91157feb40945abedd6ab346d8a4b6ac8
-  FirebaseCore: cb9ee75e0894def766167c95a4d5a14b1c138269
-  FirebaseInstanceID: ea5af6920d0a4a29b40459d055bebe4a6c1333c4
-  FirebaseMessaging: f67b3719f520ee200da0e20ce577fe2bce0c01d0
-  GoogleAppMeasurement: f7507b39b70ad0bd80b3d81518b2f43868974307
-  GoogleUtilities: 06b66f9567769a7958db20a92f0128b2843e49d5
+  Firebase: 0c8cf33f266410c61ab3e2265cfa412200351d9c
+  FirebaseAnalytics: ece1aa57a4f43c64d53a648b5a5e05151aae947b
+  FirebaseAnalyticsInterop: efbe45c8385ec626e29f9525e5ebd38520dfb6c1
+  FirebaseCore: f1a9a8be1aee4bf71a2fc0f4096df6788bdfda61
+  FirebaseInstanceID: a122b0c258720cf250551bb2bedf48c699f80d90
+  FirebaseMessaging: 4235f949ce1c4e827aeb19705ba5c53f9b85aa10
+  GoogleAppMeasurement: ffe513e90551844a739e7bcbb1d2aca1c28a4338
+  GoogleUtilities: 273e67030e0de313e7304f6dcfa96fc5214f6c23
   I: c06e4985b9a046cddacf82ab3900fe1fa1f162b1
-  nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
-  Nimble: c8d6a1f463701921c46de965c673e13cafa09196
-  Nimble-Snapshots: f5459b5b091678dc942d03ec4741cacb58ba4a52
-  Protobuf: 1eb9700044745f00181c136ef21b8ff3ad5a0fd5
-  Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
-  Result: 7645bb3f50c2ce726dd0ff2fa7b6f42bbe6c3713
-  Tsuchi: ed3b350f7a67e4662b5b936c8cc00c3f7fa52d30
+  iOSSnapshotTestCase: 944a73f6d9676302811a86c0cf35f0e6ef5ab2a0
+  nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
+  Nimble: 45f786ae66faa9a709624227fae502db55a8bdd0
+  Nimble-Snapshots: 2d6d712ceb2d1850d88f850fbd7c732618106022
+  Protobuf: 7a877b7f3e5964e3fce995e2eb323dbc6831bb5a
+  Quick: ce1276c7c27ba2da3cb2fd0cde053c3648b3b22d
+  Result: bd966fac789cc6c1563440b348ab2598cc24d5c7
+  Tsuchi: 614440581f5c8279e5def5181fe26e9f91a2e6eb
 
-PODFILE CHECKSUM: 084aa82e26e5a691f7e9f18d77fcab82c8f15979
+PODFILE CHECKSUM: 4e6ae7bff20f40cd0aec3746db40998932770c92
 
 COCOAPODS: 1.5.2

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -6,43 +6,25 @@ import Tsuchi
 
 class TableOfContentsSpec: QuickSpec {
     override func spec() {
-        describe("these will fail") {
-
-            it("can do maths") {
-                expect(1) == 2
-            }
-
-            it("can read") {
-                expect("number") == "string"
-            }
-
-            it("will eventually fail") {
-                expect("time").toEventually( equal("done") )
-            }
-            
-            context("these will pass") {
-
-                it("can do maths") {
-                    expect(23) == 23
+        describe("payload decode") {
+            context("`aps` decode") {
+                it("can decode only body field") {
+                    let payload = #"{ "alert" : "Message received from Bob" }"#
+                    expect(try? JSONDecoder().decode(APS.self, from: payload.data(using: .utf8)!)).toNot(beNil())
                 }
-
-                it("can read") {
-                    expect("🐮") == "🐮"
-                }
-
-                it("will eventually pass") {
-                    var time = "passing"
-
-                    DispatchQueue.main.async {
-                        time = "done"
+                it("can decode body and more fields") {
+                    let payload = #"""
+                    {
+                      "alert" : {
+                        "title" : "Game Request",
+                        "body" : "Bob wants to play poker",
+                        "action-loc-key" : "PLAY"
+                      },
+                      "badge" : 5
                     }
+                    """#
+                    expect(try? JSONDecoder().decode(APS.self, from: payload.data(using: .utf8)!)).toNot(beNil())
 
-                    waitUntil { done in
-                        Thread.sleep(forTimeInterval: 0.5)
-                        expect(time) == "done"
-
-                        done()
-                    }
                 }
             }
         }

--- a/Example/Tsuchi.xcodeproj/project.pbxproj
+++ b/Example/Tsuchi.xcodeproj/project.pbxproj
@@ -222,7 +222,7 @@
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
 						DevelopmentTeam = Y54QU7AU8E;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1020;
 						SystemCapabilities = {
 							com.apple.Push = {
 								enabled = 1;
@@ -232,7 +232,7 @@
 					607FACE41AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
 						DevelopmentTeam = Y54QU7AU8E;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1020;
 						TestTargetID = 607FACCF1AFB9204008FA782;
 					};
 				};
@@ -242,6 +242,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -333,6 +334,7 @@
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble-Snapshots/Nimble_Snapshots.framework",
 				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
+				"${BUILT_PRODUCTS_DIR}/iOSSnapshotTestCase/FBSnapshotTestCase.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -528,8 +530,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.demo.Tsuchi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -547,8 +548,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.demo.Tsuchi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -569,8 +569,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -587,8 +586,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Example/Tsuchi.xcodeproj/project.pbxproj
+++ b/Example/Tsuchi.xcodeproj/project.pbxproj
@@ -566,7 +566,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -583,7 +583,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/Example/Tsuchi.xcodeproj/project.pbxproj
+++ b/Example/Tsuchi.xcodeproj/project.pbxproj
@@ -289,7 +289,6 @@
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
 				"${BUILT_PRODUCTS_DIR}/I/I.framework",
 				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
-				"${BUILT_PRODUCTS_DIR}/Result/Result.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -297,7 +296,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/I.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Protobuf.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Result.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tsuchi.podspec
+++ b/Tsuchi.podspec
@@ -22,5 +22,4 @@ You can define type safe Notification object, and handle it.
 
   s.dependency 'Firebase/Core', '~>5.0'
   s.dependency 'Firebase/Messaging', '~>5.0'
-  s.dependency 'Result'
 end

--- a/Tsuchi/Classes/PushNotificationPayload.swift
+++ b/Tsuchi/Classes/PushNotificationPayload.swift
@@ -16,7 +16,24 @@ public struct APS: Decodable {
         public let body: String?
         public let title: String?
     }
+
     public let alert: Alert?
     public let badge: Int?
     public let sound: String?
+
+    enum CodingKeys: String, CodingKey {
+        case alert
+        case badge
+        case sound
+    }
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let body = try? container.decodeIfPresent(String.self, forKey: .alert) {
+            alert = Alert(body: body, title: nil)
+        } else {
+            alert = try container.decode(Alert.self, forKey: .alert)
+        }
+        badge = try container.decodeIfPresent(Int.self, forKey: .badge)
+        sound = try container.decodeIfPresent(String.self, forKey: .sound)
+    }
 }

--- a/Tsuchi/Classes/Tsuchi.swift
+++ b/Tsuchi/Classes/Tsuchi.swift
@@ -9,11 +9,10 @@ import Foundation
 import UIKit
 import UserNotifications
 import FirebaseMessaging
-import Result
 
 public class Tsuchi: NSObject {
     private struct Container<T: PushNotificationPayload>: SubscribeContainer {
-        let handler: (Result<(T, NotificationMode), AnyError>) -> Void
+        let handler: (Result<(T, NotificationMode), Error>) -> Void
 
         func parse(_ json: [AnyHashable: Any], mode: NotificationMode) {
             do {
@@ -21,7 +20,7 @@ public class Tsuchi: NSObject {
                 let notification = try JSONDecoder().decode(T.self, from: data)
                 handler(.success((notification, mode)))
             } catch let error {
-                handler(.failure(AnyError(error)))
+                handler(.failure(error))
             }
         }
     }
@@ -52,7 +51,7 @@ public class Tsuchi: NSObject {
         NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
     }
 
-    public func subscribe<T: PushNotificationPayload>(_ type: T.Type, handler: @escaping (Result<(T, NotificationMode), AnyError>) -> Void) {
+    public func subscribe<T: PushNotificationPayload>(_ type: T.Type, handler: @escaping (Result<(T, NotificationMode), Error>) -> Void) {
         self.container = AnyContainer(base: Container<T>(handler: handler))
     }
 


### PR DESCRIPTION
- Fixed payload decode logic.
  - wrote unit test.
  - Tsuchi can now decode these payload below:

```json
{
  "aps" : { 
    "alert" : "Message received from Bob" 
  },
  ...
}

{
  "aps" : {
    "alert" : {
      "title" : "Game Request",
      "body" : "Bob wants to play poker",
      "action-loc-key" : "PLAY"
    },
    "badge" : 5
  },
  ...
}
```

- Support Swift5.0.
- Replaced `Result` using Standard Libs.